### PR TITLE
Bump pc plugin to 1.15.0 for Erlang/OTP 27 compatibility

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,7 @@
 {erl_opts, [debug_info]}.
 
 {artifacts, ["priv/iconverl.so"]}.
-{plugins, [{pc, "1.13.0"}]}.
+{plugins, [{pc, "1.15.0"}]}.
 {provider_hooks, [
     {post, [
         {compile, {pc, compile}},


### PR DESCRIPTION
The port_compiler (pc) plugin 1.13.0 calls code:lib_dir/2, which is deprecated in OTP 27. Because pc compiles itself with warnings_as_errors, the deprecation fails the build ("Errors loading plugin pc") and the NIF never compiles. pc 1.15.0 removes the deprecated call.

No source changes were needed; c_src/iconverl.c and the Erlang modules are already OTP 27-clean.